### PR TITLE
Question을 입력받을때, ConverterId와 TestCaseDetailId가 추가 메핑되도록 수정

### DIFF
--- a/src/main/java/com/CodeMentor/question/dto/TestCaseDetailDTO.java
+++ b/src/main/java/com/CodeMentor/question/dto/TestCaseDetailDTO.java
@@ -2,6 +2,8 @@ package com.CodeMentor.question.dto;
 
 import lombok.*;
 
+import java.util.ArrayList;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -11,4 +13,5 @@ public class TestCaseDetailDTO {
 
     private String testCaseKey;
     private String testCaseValue;
+    private ArrayList<Integer> converterIds;
 }

--- a/src/main/java/com/CodeMentor/question/service/QuestionService.java
+++ b/src/main/java/com/CodeMentor/question/service/QuestionService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Required;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.ArrayList;
 
 @Service
@@ -28,6 +29,7 @@ public class QuestionService {
     private final QuestionConstraintRepository questionConstraintRepository;
     private final ConverterMapRepository converterMapRepository;
 
+    @Transactional
     public Integer questionInput(QuestionInputRequest request) {
         Question question = Question.builder()
                 .title(request.getQuestionTitle())
@@ -47,6 +49,7 @@ public class QuestionService {
         return response.getId().intValue();
     }
 
+    @Transactional
     public Integer testCaseInput(TestCaseRequest request) {
         Question question = questionRepository.findById((long) request.getQuestionId()).orElseThrow();
 
@@ -82,6 +85,7 @@ public class QuestionService {
         return questionTestCaseResponse.getId().intValue();
     }
 
+    @Transactional
     public Integer converterInput(ConverterInputRequest request) {
         Language languageEntity = languageRepository.findByType(request.getLanguageType()).orElseThrow();
 
@@ -96,6 +100,7 @@ public class QuestionService {
         return response.getId().intValue();
     }
 
+    @Transactional
     public Integer questionCodeInput(QuestionCodeInputRequest request) {
         Question question = questionRepository.findById((long)request.getQuestionId()).orElseThrow();
         Language language = languageRepository.findByType(request.getLanguageType()).orElseThrow();

--- a/src/main/java/com/CodeMentor/question/service/QuestionService.java
+++ b/src/main/java/com/CodeMentor/question/service/QuestionService.java
@@ -26,7 +26,6 @@ public class QuestionService {
     private final QuestionTestCaseDetailRepository questionTestCaseDetailRepository;
     private final CodeExecConverterRepository codeExecConverterRepository;
     private final QuestionConstraintRepository questionConstraintRepository;
-
     private final ConverterMapRepository converterMapRepository;
 
     public Integer questionInput(QuestionInputRequest request) {
@@ -65,18 +64,19 @@ public class QuestionService {
                     .key(request.getTestCaseDetailDTOs().get(i).getTestCaseKey())
                     .value(request.getTestCaseDetailDTOs().get(i).getTestCaseValue())
                     .build();
+            questionTestCaseDetailRepository.save(questionTestCaseDetail);
+
             ArrayList<Integer> converterIds = request.getTestCaseDetailDTOs().get(i).getConverterIds();
 
             // 각 TestCaseDetailId와 ConverterId를 ConverterMap에 저장
-            for (int j = 0; j < converterIds.size(); j++) {
-                CodeExecConverter codeExecConverter = codeExecConverterRepository.findById((long) converterIds.get(j)).orElseThrow();
+            for (Integer converterId : converterIds) {
+                CodeExecConverter codeExecConverter = codeExecConverterRepository.findById((long) converterId).orElseThrow();
                 ConverterMap converterMap = ConverterMap.builder()
                         .questionTestCaseDetail(questionTestCaseDetail)
                         .codeExecConverter(codeExecConverter)
                         .build();
                 converterMapRepository.save(converterMap);
             }
-            questionTestCaseDetailRepository.save(questionTestCaseDetail);
         }
 
         return questionTestCaseResponse.getId().intValue();


### PR DESCRIPTION
## Purpose(Issue)

DTO에 ConverterId를 받고,
Service에서 ConverterId, DetailId를 Converter_Map 테이블에 추가 저장

## Key Changes

당신이 작업한 내용의 주요 변경사항을 자세히 나열하세요.

- Change 1 (0b64e3679ec81cae26a22e626147f7bd74ec0570)
  - [ConverterId와 TestCadeDetailId가 메핑되도록 수정](https://github.com/CodeMentor-CodingSite/JavaServer/commit/0b64e3679ec81cae26a22e626147f7bd74ec0570)
- Change 2 ([2d924af](https://github.com/CodeMentor-CodingSite/JavaServer/pull/21/commits/2d924afa8b69c47c394d91c791748f2064676383))
  - 저장되는 entity 순서에 따른 오류 수정
- Change 3 ([2ac2b15](https://github.com/CodeMentor-CodingSite/JavaServer/pull/21/commits/2ac2b1569686a215c200f1bfbb4259bc9c530cc1))
  - @Transactional어노테이션 추가

## To reviewers

이 PR을 확인 할 Code Reviewer에게 남길 메세지를 작성하세요.
